### PR TITLE
IsNull crashing when value is null

### DIFF
--- a/lib/EmbedCodeGenerator.js
+++ b/lib/EmbedCodeGenerator.js
@@ -204,6 +204,12 @@ EmbedCodeGenerator.prototype = {
 	* @return {Boolean}
 	*/
 	isNull: function( property ) {
+
+		// Null ?
+		if (property === null) {
+			return true;
+		}
+
 		if (property.length && property.length > 0) {
 			return false;
 		}


### PR DESCRIPTION
When forgetting the widgetId it crashes as it get .lenght on null.
Tried the example 
`var gen = new kEmbedCodeGenerator({
	'host': 'cdnapi.kaltura.com',
	'partnerId': 0000,
	'width': 680,
	'height': 420
});
gen.getCode();`